### PR TITLE
added env var for install tree testing, removed build on test for ext…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,6 @@ endif
 include $(ACT_HOME)/scripts/Makefile.std
 
 $(EXE): $(OBJS) $(ACTPASSDEPEND) ext/lxt2_write.o
-	$(CXX) $(CFLAGS) $(OBJS) ext/lxt2_write.o -o $(EXE) $(LIBACTPASS) $(LIBASIM) $(LIBACTSCMCLI) -lm -ldl -ledit $(LIBXYCE) -lz
+	$(CXX) $(SH_EXE_OPTIONS) $(CFLAGS) $(OBJS) ext/lxt2_write.o -o $(EXE) $(LIBACTPASS) $(LIBASIM) $(LIBACTSCMCLI) -lm -ldl -ledit $(LIBXYCE) -lz
 
 -include Makefile.deps

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -4,8 +4,8 @@
 #
 #
 
-runtest: all
-runtestsub: all
+runtest:
+runtestsub:
 installincsub: all
 installsub: all
 install: all

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh 
 
-./run_num.sh
-./run_inf.sh
+./run_num.sh || exit 1
+./run_inf.sh || exit 1

--- a/test/run_inf.sh
+++ b/test/run_inf.sh
@@ -7,7 +7,13 @@ echo
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../actsim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../actsim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/actsim
+  echo "testing installation"
+  echo
+else
+  ACTTOOL=../actsim.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -58,6 +64,9 @@ EOF
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+			diff runs/$i.t.stdout runs/$i.stdout
+		fi
 	fi
  	sort runs/$i.t.stderr > runs/$i.ts.stderr
  	sort runs/$i.stderr > runs/$i.os.stderr
@@ -71,6 +80,9 @@ EOF
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+			diff runs/$i.ts.stderr runs/$i.os.stderr
+		fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/test/run_num.sh
+++ b/test/run_num.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../actsim.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../actsim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/actsim
+  echo "testing installation"
+  echo
+else
+  ACTTOOL=../actsim.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ EOF
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+			diff runs/$i.t.stdout runs/$i.stdout
+		fi
 	fi
  	sort runs/$i.t.stderr > runs/$i.ts.stderr
  	sort runs/$i.stderr > runs/$i.os.stderr
@@ -79,6 +88,9 @@ EOF
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+			diff runs/$i.ts.stderr runs/$i.os.stderr
+		fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/test/validate_inf.sh
+++ b/test/validate_inf.sh
@@ -3,7 +3,13 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../actsim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../actsim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/actsim
+  echo "testing installation"
+  echo
+else
+  ACTTOOL=../actsim.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/test/validate_num.sh
+++ b/test/validate_num.sh
@@ -3,7 +3,13 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../actsim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../actsim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/actsim
+  echo "testing installation"
+  echo
+else
+  ACTTOOL=../actsim.$EXT
+fi
 
 if [ $# -eq 0 ]
 then


### PR DESCRIPTION
…, added shared linker options to executable build

changes:

- I removed that ext is build on make test, as the test environments in https://github.com/asyncvlsi/actflow/pull/1 are bare OSes that do not necessary have a compiler tool chain installed, and the building on test is not testing anything extra as its also build on build and install.
- I added the SH_EXE_OPTIONS to the build command so the RPATH is set in the executable correctly and the binary works path independent
- added $ACT_TEST_INSTALL to trigger testing of installed sources in $ACT_HOME
- added $ACT_TEST_VERBOSE to print got vs expected output for CI, on failure, because the files in the ci are not accessible to actually check what went wrong.
- make test now returns exit 1 on failure and not 0 - all passed

if both are not set the it behaves as before

required for pr https://github.com/asyncvlsi/actflow/pull/1