### PR TITLE
New simuation library components for verification

### DIFF
--- a/simlib/Makefile
+++ b/simlib/Makefile
@@ -22,7 +22,7 @@ SHLIB=libactsimext_sh_$(EXT).so
 
 TARGETLIBS=$(SHLIB)
 TARGETCONF=actsim.conf
-TARGETACT=sim.act rand.act _all_.act
+TARGETACT=sim.act rand.act scoreboards.act sources.act _all_.act
 TARGETACTSUBDIR=sim
 
 OBJS=random.os rom.os file.os rand_r.os

--- a/simlib/_all_.act
+++ b/simlib/_all_.act
@@ -19,4 +19,6 @@
  **************************************************************************
  */
 import "sim/sim.act";
+import "sim/scoreboards.act";
+import "sim/sources.act";
 import "sim/rand.act";

--- a/simlib/scoreboards.act
+++ b/simlib/scoreboards.act
@@ -1,0 +1,213 @@
+/*************************************************************************
+ *
+ *  This file is part of ACT standard library
+ *
+ *  Copyright (c) 2022 Rajit Manohar
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ **************************************************************************
+ */
+
+namespace sim {
+
+/*
+ * Lockstep scoreboard
+ *
+ * Use this for a simple linear pipeline
+ *
+ * Features:
+ * - Input token logging
+ * - Input token to output token matching
+ * - Output token comparison
+ * - Token counter
+ *
+ * Assumes:
+ * - Input token corresponds directly to output token
+ * - Same number of tokens on all channels
+ * - Tokens on all channels in same order
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - IN_CHANNELS: Number of input channels going to the model / design
+ * - OUT_CHANNELS: Number of output channels coming from the model / design
+ * - VERBOSE_TESTING: If false, only failed tests are logged
+ *
+ */
+export template <pint D_WIDTH, IN_CHANNELS, OUT_CHANNELS; pbool VERBOSE_TESTING>
+defproc scoreboard_lockstep(chan?(int<D_WIDTH>) IN[IN_CHANNELS], OUT_M[OUT_CHANNELS], OUT_D[OUT_CHANNELS])
+{
+    int<D_WIDTH> input[IN_CHANNELS], output_m[OUT_CHANNELS], output_d[OUT_CHANNELS];
+    bool not_failed;
+    int num;
+
+    chp {
+        
+        num := 0;
+
+        *[
+            // receive the data
+            (, i : IN_CHANNELS : IN[i]?input[i]);
+            (, i : OUT_CHANNELS : OUT_M[i]?output_m[i]),
+            (, j : OUT_CHANNELS : OUT_D[j]?output_d[j]);
+
+            // check the results
+            not_failed+;
+            (; i : OUT_CHANNELS : [not_failed -> not_failed := output_m[i] = output_d[i] [] else -> skip]);
+
+            // print the output
+            [ not_failed -> (
+                // only print successful tests if verbose testing is enabled
+                [ VERBOSE_TESTING -> (
+                    log_st ("");
+                    log_p ("TEST SUCCESS (", num, "): inputs {");
+                    (; i : IN_CHANNELS : log_p (i, ": ", input[i], "%x (0x", input[i], ") "));
+                    log_p ("}, outputs {");
+                    (; i : OUT_CHANNELS : log_p (i, ": ", output_d[i], "%x (0x", output_d[i], ") "));
+                    log_p ("}");
+                    log_nl ("")
+                )
+                [] else -> (
+                    skip
+                )]
+            )
+            []  else -> (
+                log_st ("");
+                log_p ("TEST FAILED (", num, "): inputs {");
+                (; i : IN_CHANNELS : log_p (i, ": ", input[i], "%x (0x", input[i], ") "));
+                log_p ("}, outputs {");
+                (; i : OUT_CHANNELS : log_p (i, ": expected ", output_m[i], "%x (0x", output_m[i], "), got ", output_d[i], "%x (0x", output_d[i], ") "));
+                log_p ("}");
+                log_nl ("")
+            )];
+            num := num + 1
+        ]
+
+    }
+}
+
+/*
+ * Deterministic output only scoreboard
+ *
+ * Use one instance of this for each end of a deterministic pipeline
+ *
+ * Features:
+ * - Output token comparison
+ * - Token counter
+ *
+ * Assumes:
+ * - Same number of tokens on all channels
+ * - Tokens on all channels in same order
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels coming from the model / design where #tokens is identical
+ * - VERBOSE_TESTING: If false, only failed tests are logged
+ *
+ */
+export template <pint D_WIDTH, OUT_CHANNELS; pbool VERBOSE_TESTING>
+defproc scoreboard_deterministic(chan?(int<D_WIDTH>) OUT_M[OUT_CHANNELS], OUT_D[OUT_CHANNELS])
+{
+    int<D_WIDTH> output_m[OUT_CHANNELS], output_d[OUT_CHANNELS];
+    bool not_failed;
+    int num;
+
+    chp {
+
+        num := 0;
+
+        *[
+            // receive the data
+            (, i : OUT_CHANNELS : OUT_M[i]?output_m[i]),
+            (, j : OUT_CHANNELS : OUT_D[j]?output_d[j]);
+
+            // check the results
+            not_failed+;
+            (; i : OUT_CHANNELS : [not_failed -> not_failed := output_m[i] = output_d[i] [] else -> skip]);
+
+            // print the output
+            [ not_failed -> (
+                
+                // only print successful tests if verbose testing is enabled
+                [ VERBOSE_TESTING -> (
+                    log_st ("");
+                    log_p ("TEST SUCCESS (", num, "): outputs {");
+                    (; i : OUT_CHANNELS : log_p (i, ": ", output_d[i], "%x (0x", output_d[i], ") "));
+                    log_p ("}");
+                    log_nl ("")
+                ) 
+                []  else -> (
+                    skip
+                )]
+            )
+            []  else -> (
+                log_st ("");
+                log_p ("TEST FAILED (", num, "): outputs {");
+                (; i : OUT_CHANNELS : log_p (i, ": expected ", output_m[i], "%x (0x", output_m[i], "), got ", output_d[i], "%x (0x", output_d[i], ") "));
+                log_p ("}");
+                log_nl ("")
+            )];
+            num := num + 1
+        ]
+
+    }
+
+}
+
+/*
+ * Input token logger
+ * 
+ * Use this if you are not using a scoreboard with input token logging
+ * 
+ * Features:
+ * 1. Input token logging
+ * 2. Token counter
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - IN_CHANNELS: Number of input channels going to the model / design where #tokens is identical
+ * - VERBOSE_TESTING: If false, inputs are not logged
+ *
+ */
+export template <pint D_WIDTH, IN_CHANNELS; pbool VERBOSE_TESTING>
+defproc input_logger(chan?(int<D_WIDTH>) IN[IN_CHANNELS])
+{
+    int<D_WIDTH> input[IN_CHANNELS];
+    int num;
+    
+    chp {
+
+        num := 0;
+
+        *[
+            // receive the data
+            (, i : IN_CHANNELS : IN[i]?input[i]);
+
+            // only print logged input tokens if verbose testing is enabled
+            [ VERBOSE_TESTING -> (
+                log_st ("");
+                log_p ("INPUT TOKEN (", num, "): inputs {");
+                (; i : IN_CHANNELS : log_p (i, ": ", input[i], "%x (0x", input[i], ") "));
+                log_p ("}");
+                log_nl ("")
+            )
+            []  else -> (
+                skip
+            )];
+            num := num + 1
+        ]
+
+    }
+}
+
+}

--- a/simlib/sim.act
+++ b/simlib/sim.act
@@ -27,6 +27,15 @@ defproc source (chan!(int<W>) O)
     *[ O!V ]
   }
 }
+
+export template<pint W; pbool REP; pint N; pint data[N]>
+defproc source_seq(chan!(int<W>) O)
+{
+  int i;
+  chp {
+    *[ i := 0; *[ i < N -> [([]k:N: i=k -> O!data[k])]; i := i + 1 ] <- REP ]
+  }
+}
   
 export template<pbool LOG; pint W>
 defproc sink(chan?(int<W>) I)

--- a/simlib/sim.act
+++ b/simlib/sim.act
@@ -27,15 +27,6 @@ defproc source (chan!(int<W>) O)
     *[ O!V ]
   }
 }
-
-export template<pint W; pbool REP; pint N; pint data[N]>
-defproc source_seq(chan!(int<W>) O)
-{
-  int i;
-  chp {
-    *[ i := 0; *[ i < N -> [([]k:N: i=k -> O!data[k])]; i := i + 1 ] <- REP ]
-  }
-}
   
 export template<pbool LOG; pint W>
 defproc sink(chan?(int<W>) I)
@@ -83,6 +74,26 @@ defproc check_sink(chan?(int<W>) I)
   }
 }
 
+export template<pint W; pbool REP; pint N; pint data[N]>
+defproc check_sink_seq(chan?(int<W>) I)
+{
+  int<W> x, y;
+  int i;
+  chp {
+    *[ 
+      i := 0; 
+      *[ i < N -> [(
+          []k:N: i=k -> y := data[k];
+          I?x;
+          [ x = y -> skip
+          [] else -> log ("ASSERTION failed, value mismatch; expected: ", y, "%x (0x", y, "); got: ", x, "%x (0x", x, ")")
+          ]        
+        )]; 
+        i := i + 1 
+      ] 
+    <- REP ]
+  }
+}
 
 export template<pint ID; pint W>
 defproc file_sink(chan?(int<W>) I)
@@ -92,6 +103,36 @@ defproc file_sink(chan?(int<W>) I)
   chp {
     dummy := file_create(ID);
     *[ I?x; dummy := file_write(ID, x) ]
+  }
+}
+
+export template<pint LOG_ID; pint W>
+defproc logger(chan?(int<W>) I; chan!(int<W>) O)
+{
+  int <W> b;
+  chp {
+    *[
+      I?b;
+      log ("Logger ", LOG_ID, ": Received value ", b, "%x (0x", b, ")");
+      O!b
+    ]
+  }
+}
+
+
+export template<pint FILE_ID, W>
+defproc logger_file(chan?(int<W>) I; chan!(int<W>) O)
+{
+  int<W> b;
+  bool dummy;
+  chp {
+    dummy := file_create(FILE_ID);
+    
+    *[ 
+      I?b; 
+      dummy := file_write(FILE_ID, b);
+      O!b
+    ]
   }
 }
   

--- a/simlib/sources.act
+++ b/simlib/sources.act
@@ -1,0 +1,235 @@
+/*************************************************************************
+ *
+ *  This file is part of ACT standard library
+ *
+ *  Copyright (c) 2022 Rajit Manohar
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ **************************************************************************
+ */
+
+namespace sim {
+
+// external C functions for file interaction
+export function file_read(int<32> idx) : int<64>;
+export function file_eof(int<32> idx) : bool;
+export function file_close(int<32> idx) : bool;
+
+/*
+ * Simple static source with one output channel
+ *
+ * Use this if you need the simplest of sources
+ *
+ * Features:
+ * - Static output token generation
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - VALUE: Static value to output
+ *
+ */
+export template<pint D_WIDTH, VALUE>
+defproc source_static (chan!(int<D_WIDTH>) O)
+{
+    chp {
+        *[ O!VALUE ]
+    }
+}
+
+/*
+ * Simple static source
+ *
+ * Use this if you need a multi-ended source with static output
+ *
+ * Features:
+ * - Static output token generation
+ * - Configurable number of outputs
+ * - All outputs complete send before next token is sent
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels
+ * - VALUE: Static value to output
+ *
+ */
+export template<pint D_WIDTH, OUT_CHANNELS, VALUE>
+defproc source_static_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
+{
+    chp {
+        *[
+            (, i : OUT_CHANNELS : O[i]!VALUE)
+        ]
+    }
+}
+
+/*
+ * Simple sequential source with one output channel
+ *
+ * Use this if you need a source which outputs a sequence
+ * of values (repeatedly)
+ *
+ * Features:
+ * - Outputs sequence of tokens
+ * - Can be set to repeat the sequence indefinitely
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - N: Number of values in the sequence
+ * - DATA: The sequence as a vector of pint
+ * - LOOP: Repeat the sequence indefinitely
+ *
+ */
+export template<pint D_WIDTH, N; pint DATA[N]; pbool LOOP>
+defproc source_seq (chan!(int<D_WIDTH>) O)
+{
+    int i;
+
+    chp {
+        *[
+            i := 0; 
+            *[ i < N -> 
+                // select the right element and send it
+                [([]k:N: i=k -> O!DATA[k])]; 
+                i := i + 1 
+            ] 
+        <- LOOP ]
+  }
+}
+
+/*
+ * Simple sequential source
+ *
+ * Use this if you need a source which outputs a sequence
+ * of values (repeatedly) to multiple outputs
+ *
+ * Features:
+ * - Outputs sequence of tokens
+ * - Can be set to repeat the sequence indefinitely
+ * - All outputs complete send before next token is sent
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels
+ * - N: Number of values in the sequence
+ * - DATA: The sequence as a vector of pint
+ * - LOOP: Repeat the sequence indefinitely
+ *
+ */
+export template<pint D_WIDTH, OUT_CHANNELS, N; pint DATA[N]; pbool LOOP>
+defproc source_seq_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
+{
+    int i;
+
+    chp {
+        *[
+            i := 0; 
+            *[ i < N -> 
+                // select the right element and send it
+                [([]k:N: i=k -> (, j : OUT_CHANNELS : O[j]!DATA[k]))]; 
+                i := i + 1 
+            ] 
+        <- LOOP ]
+    }
+}
+  
+/*
+ * Simple file source with one output channel
+ *
+ * Use this if you need a source which outputs a sequence
+ * of values (repeatedly) from a file
+ *
+ * Features:
+ * - Outputs sequence of tokens from a file
+ * - Can be set to repeat the sequence indefinitely
+ *
+ * Assumptions:
+ * - File is only accessed by one instance
+ * - File has at least one value entry
+ * - Values in file are newline separated
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - F_ID: The ID of the file (see actsim documentation)
+ * - LOOP: Repeat the sequence indefinitely
+ *
+ */
+export template<pint D_WIDTH, F_ID; pbool LOOP>
+defproc source_file (chan!(int<D_WIDTH>) O)
+{
+    bool dummy;
+
+    chp {
+        // if we are set to loop, loop forever
+        *[
+            // read until the file reports EOF and send it to the output channel
+            *[ 
+                O!file_read(F_ID) 
+            <- ~file_eof (F_ID) ];
+
+            // close the file
+            dummy := file_close(F_ID) 
+        <- LOOP ];
+
+        log ("Source file #", F_ID, " ends.")
+    }
+}
+
+/*
+ * Simple file source
+ *
+ * Use this if you need a source which outputs a sequence
+ * of values (repeatedly) from a file to multiple outputs
+ *
+ * Features:
+ * - Outputs sequence of tokens from a file
+ * - Can be set to repeat the sequence indefinitely
+ * - All outputs complete send before next token is sent
+ *
+ * Assumptions:
+ * - File is only accessed by one instance
+ * - File has at least one value entry
+ * - Values in file are newline separated
+ *
+ * Parameters:
+ * - D_WIDTH: Data output bus width
+ * - OUT_CHANNELS: Number of output channels
+ * - F_ID: The ID of the file (see actsim documentation)
+ * - LOOP: Repeat the sequence indefinitely
+ *
+ */
+export template<pint D_WIDTH, OUT_CHANNELS, F_ID; pbool LOOP>
+defproc source_file_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
+{
+    bool dummy;
+    int<D_WIDTH> buf;
+
+    chp {
+
+        // if we are set to loop, loop forever
+        *[
+            // read until the file reports EOF and send it to the output channel
+            *[
+                buf := file_read(F_ID);
+                (, i : OUT_CHANNELS : O[i]!buf)
+            <- ~file_eof (F_ID) ];
+
+            // close the file
+            dummy := file_close(F_ID) 
+        <- LOOP ];
+
+        log ("Source file #", F_ID, " ends.")
+  }
+}
+
+}

--- a/simlib/sources.act
+++ b/simlib/sources.act
@@ -91,7 +91,7 @@ defproc source_static_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
  *
  */
 export template<pint D_WIDTH, N; pint DATA[N]; pbool LOOP>
-defproc source_seq (chan!(int<D_WIDTH>) O)
+defproc source_sequence (chan!(int<D_WIDTH>) O)
 {
     int i;
 
@@ -127,7 +127,7 @@ defproc source_seq (chan!(int<D_WIDTH>) O)
  *
  */
 export template<pint D_WIDTH, OUT_CHANNELS, N; pint DATA[N]; pbool LOOP>
-defproc source_seq_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
+defproc source_sequence_multi (chan!(int<D_WIDTH>) O[OUT_CHANNELS])
 {
     int i;
 


### PR DESCRIPTION
These changes should enable more comprehensive verification functionality for actsim.
List of changes in no particular order:

- Added assertion support (halt simulation)
- Added log_st, log_p, and log_nl functions, so log lines can be constructed in CHP programmatically (needed for parameterizeable sim lib components)
- Added two scoreboards, one for pipelines where all inputs and outputs see the identical number of tokens (scoreboard_lockstep) and one where only a set of outputs see the same number of tokens in the same order (scoreboard_deterministic) (verbose and non-verbose logging modes supported with parameter)
- Added an input logger for situations where scoreboard_lockstep cannot be used (verbose and non-verbose logging modes supported with parameter)
- Added multi-ended sources so tokens can be fed to DUT and logger without additional effort

The added components have a standardized parameter naming and ordering scheme and are fully documented.
Naming does not overlap with existing components.

These components are already used in the act-starter repository template.